### PR TITLE
v1.0.2 bugfix - Duplicating sprites

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frogrilla.sprite",
 	"displayName": "Sprite",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Allows images to be loaded and drawn with sprites. Sprite Config Generator is required to import images.",
 	"main": "src/main.luau",
 	"keywords": [

--- a/src/manager.luau
+++ b/src/manager.luau
@@ -109,7 +109,10 @@ function Manager.OnGui(self: types.Manager)
 				Gui.sameLine()
 
 				if Gui.button("Duplicate " .. Icon.Copy) then
-					table.insert(self.sprites, table.clone(sprite))
+					local copy = Sprite.Create(sprite.image)
+					copy.transform = table.clone(sprite.transform)
+					copy.id ..= " (copy)"
+					table.insert(self.sprites, copy)
 					self.spriteIndex = #self.sprites
 				end
 


### PR DESCRIPTION
Duplicating sprites previously created two sprites that shared the same transform, this is now fixed.